### PR TITLE
Improving path management for catkin ws sourcing

### DIFF
--- a/scripts/init_ros_client.sh
+++ b/scripts/init_ros_client.sh
@@ -71,7 +71,7 @@ source /opt/ros/$ros_distro/setup.bash
 if [ $USING_CATKIN_WS -eq 1 ]
 then
     echo "-- Initializing ROS workspace: $CATKIN_WS"
-    source ~/$CATKIN_WS/devel/setup.sh
+    source $CATKIN_WS/devel/setup.sh
 fi
 
 # Connect to other Roscore (ROS_IP of this PC. ROS_MASTER_URI of the target roscore IP)

--- a/scripts/init_ros_local.sh
+++ b/scripts/init_ros_local.sh
@@ -60,5 +60,5 @@ source /opt/ros/$ros_distro/setup.bash
 if [ $USING_CATKIN_WS -eq 1 ]
 then
     echo "-- Initializing ROS workspace: $CATKIN_WS"
-    source ~/$CATKIN_WS/devel/setup.sh
+    source $CATKIN_WS/devel/setup.sh
 fi

--- a/scripts/init_ros_server.sh
+++ b/scripts/init_ros_server.sh
@@ -65,7 +65,7 @@ source /opt/ros/$ros_distro/setup.bash
 if [ $USING_CATKIN_WS -eq 1 ]
 then
     echo "-- Initializing ROS workspace: $CATKIN_WS"
-    source ~/$CATKIN_WS/devel/setup.sh
+    source $CATKIN_WS/devel/setup.sh
 fi
 
 # Connect to other Roscore (ROS_IP of this PC. ROS_MASTER_URI of the target roscore IP)


### PR DESCRIPTION
Avoiding extra user root folders being pre-pended to catkin ws path

Solves errors such as this:
/home/levko/repos/ros_connection_utils/scripts/init_ros_local.sh: line 63: /home/levko//home/levko/catkin_ws/devel/setup.sh: No such file or directory